### PR TITLE
docs(readme): warn that Airhex tail logos require a paid account

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ entities:
 
 ### Tail Airline Logos
 
+> **Note:** Airhex no longer provides logos without authorization — a paid account is required to use this feature.
+
 <img src="https://airhex.com/images/photos/airline-tail-logos.png" alt="Airhex Tail Logos" width="48%" />
 
 If you prefer different airline logos, you can use [Airhex](https://airhex.com/api/logos/) tail logos by setting the `template_airline_logo_url` option:


### PR DESCRIPTION
## Summary

Adds a note to the README clarifying that Airhex no longer provides tail logos without authorization — a paid account is required to use the `template_airline_logo_url` feature.

## Changes

- Added a `> **Note:**` callout in the *Tail Airline Logos* section of README.md